### PR TITLE
Support factor-valued raster layers in map_*() functions, fixes #7

### DIFF
--- a/R/map_breakdown.R
+++ b/R/map_breakdown.R
@@ -35,6 +35,7 @@ map_breakdown = function(explainer, raster_obs, maxcell = 1000, ...,
   x_df = as.data.frame(raster_obs, na.rm = FALSE)
   if (type %in% c("break_down")) {
     result = cbind(intercept = NA, x_df)
+    result[] = NA
   } else if (type == "break_down_interactions"){
     stop("'break_down_interactions' are not yet implemented. Please contact us if you need this feature",
          call. = FALSE)

--- a/R/map_breakdown.R
+++ b/R/map_breakdown.R
@@ -7,13 +7,13 @@
 #' See the documentation of the [`DALEX::predict_parts()`] function for more details.
 #'
 #' @param explainer a model to be explained, preprocessed by the [`DALEX::explain()`] function
-#' @param raster_obs a raster object with the observations to be explained (predictors used in the model)
+#' @param raster_obs a SpatRaster object with the observations to be explained (predictors used in the model)
 #' @param maxcell the maximum number of cells in the raster. If the number of cells in the raster is greater than `maxcell`, the function will sample `maxcell` cells from the raster. By default 1000
 #' @param ... other parameters that will be passed to [`iBreakDown::break_down()`]
 #' @param N the maximum number of observations used for calculation of attributions. By default NULL (use all)
 #' @param type the type of variable attributions. Either `break_down` or `break_down_interactions`
 #'
-#' @return A raster object with the same dimensions as `raster_obs`. The number of layers equal to the number of variables in the model plus one.
+#' @return A SpatRaster object with the same dimensions as `raster_obs`. The number of layers in it is equal to the number of variables in the model plus one.
 #' @export
 #'
 #' @references Lundberg, S. (2017). A unified approach to interpreting model predictions. arXiv preprint arXiv:1705.07874.

--- a/R/map_lime.R
+++ b/R/map_lime.R
@@ -3,12 +3,12 @@
 #' For each observation in the raster, the function returns an explanation of the model prediction using selected implementation of the LIME (Local Interpretable Model-agnostic Explanations) method.
 #'
 #' @param explainer a model to be explained, preprocessed by the [`DALEX::explain()`] function
-#' @param raster_obs a raster object with the observations to be explained (predictors used in the model)
+#' @param raster_obs a SpatRaster object with the observations to be explained (predictors used in the model)
 #' @param maxcell the maximum number of cells in the raster. If the number of cells in the raster is greater than `maxcell`, the function will sample `maxcell` cells from the raster. By default 1000
 #' @param ... additional parameters passed to the [`DALEXtra::predict_surrogate()`] function
 #' @param type the type of the LIME method implementation. Possible values are: `"localModel"` (default), `"iml"`, and `"lime"`
 #'
-#' @return A raster object with the same dimensions as `raster_obs`. The number of layers may vary depending on the type of the LIME method implementation
+#' @return A SpatRaster object with the same dimensions as `raster_obs`. The number of layers it has may vary depending on the type of the LIME method implementation
 #' @export
 #'
 #' @examples

--- a/R/map_oscillations.R
+++ b/R/map_oscillations.R
@@ -7,13 +7,13 @@
 #' See the documentation of the [`DALEX::predict_parts()`] function for more details.
 #'
 #' @param explainer a model to be explained, preprocessed by the [`DALEX::explain()`] function
-#' @param raster_obs a raster object with the observations to be explained (predictors used in the model)
+#' @param raster_obs a SpatRaster object with the observations to be explained (predictors used in the model)
 #' @param maxcell the maximum number of cells in the raster. If the number of cells in the raster is greater than `maxcell`, the function will sample `maxcell` cells from the raster. By default 1000
 #' @param ... other parameters that will be passed to [`iBreakDown::break_down()`]
 #' @param N the maximum number of observations used for calculation of attributions. By default 500
 #' @param type the type of variable attributions. Either `oscillations_uni` (default), `oscillations_emp`, `oscillations`
 #'
-#' @return A raster object with the same dimensions as `raster_obs`. The number of layers equal to the number of variables in the model.
+#' @return A SpatRaster object with the same dimensions as `raster_obs`. The number of layers in it is equal to the number of variables in the model.
 #' @export
 #'
 #' @references Lundberg, S. (2017). A unified approach to interpreting model predictions. arXiv preprint arXiv:1705.07874.

--- a/R/map_oscillations.R
+++ b/R/map_oscillations.R
@@ -34,6 +34,7 @@ map_oscillations = function(explainer, raster_obs, maxcell = 1000, ...,
   }
   x_df = as.data.frame(raster_obs, na.rm = FALSE)
   result = x_df
+  result[] = NA
   for (i in seq_len(nrow(x_df))){
     if (stats::complete.cases(x_df[i, ])){
       pp = DALEX::predict_parts(explainer, new_observation = x_df[i, ], ..., N = N, type = type)

--- a/R/map_shap.R
+++ b/R/map_shap.R
@@ -7,13 +7,13 @@
 #' See the documentation of the [`DALEX::predict_parts()`] function for more details.
 #'
 #' @param explainer a model to be explained, preprocessed by the [`DALEX::explain()`] function
-#' @param raster_obs a raster object with the observations to be explained (predictors used in the model)
+#' @param raster_obs a SpatRaster object with the observations to be explained (predictors used in the model)
 #' @param maxcell the maximum number of cells in the raster. If the number of cells in the raster is greater than `maxcell`, the function will sample `maxcell` cells from the raster. By default 1000
 #' @param ... other parameters that will be passed to [`iBreakDown::break_down()`]
 #' @param N the maximum number of observations used for calculation of attributions. By default NULL (use all)
 #' @param type the type of variable attributions. Only `"shap"` is implemented at the moment.
 #'
-#' @return A raster object with the same dimensions as `raster_obs`. The number of layers equal to the number of variables in the model.
+#' @return A SpatRaster object with the same dimensions as `raster_obs`. The number of layers in it is equal to the number of variables in the model.
 #' @export
 #'
 #' @references Lundberg, S. (2017). A unified approach to interpreting model predictions. arXiv preprint arXiv:1705.07874.

--- a/R/map_shap.R
+++ b/R/map_shap.R
@@ -33,6 +33,7 @@ map_shap = function(explainer, raster_obs, maxcell = 1000, ..., N = NULL, type =
   }
   x_df = as.data.frame(raster_obs, na.rm = FALSE)
   result = x_df
+  result[] = NA
   for (i in seq_len(nrow(x_df))){
     if (stats::complete.cases(x_df[i, ])){
       pp = DALEX::predict_parts(explainer, new_observation = x_df[i, ], ..., N = N, type = type)

--- a/man/map_breakdown.Rd
+++ b/man/map_breakdown.Rd
@@ -16,7 +16,7 @@ map_breakdown(
 \arguments{
 \item{explainer}{a model to be explained, preprocessed by the \code{\link[DALEX:explain]{DALEX::explain()}} function}
 
-\item{raster_obs}{a raster object with the observations to be explained (predictors used in the model)}
+\item{raster_obs}{a SpatRaster object with the observations to be explained (predictors used in the model)}
 
 \item{maxcell}{the maximum number of cells in the raster. If the number of cells in the raster is greater than \code{maxcell}, the function will sample \code{maxcell} cells from the raster. By default 1000}
 
@@ -27,7 +27,7 @@ map_breakdown(
 \item{type}{the type of variable attributions. Either \code{break_down} or \code{break_down_interactions}}
 }
 \value{
-A raster object with the same dimensions as \code{raster_obs}. The number of layers equal to the number of variables in the model plus one.
+A SpatRaster object with the same dimensions as \code{raster_obs}. The number of layers in it is equal to the number of variables in the model plus one.
 }
 \description{
 This function calculates the attributions of the model

--- a/man/map_lime.Rd
+++ b/man/map_lime.Rd
@@ -9,7 +9,7 @@ map_lime(explainer, raster_obs, maxcell = 1000, ..., type = "localModel")
 \arguments{
 \item{explainer}{a model to be explained, preprocessed by the \code{\link[DALEX:explain]{DALEX::explain()}} function}
 
-\item{raster_obs}{a raster object with the observations to be explained (predictors used in the model)}
+\item{raster_obs}{a SpatRaster object with the observations to be explained (predictors used in the model)}
 
 \item{maxcell}{the maximum number of cells in the raster. If the number of cells in the raster is greater than \code{maxcell}, the function will sample \code{maxcell} cells from the raster. By default 1000}
 
@@ -18,7 +18,7 @@ map_lime(explainer, raster_obs, maxcell = 1000, ..., type = "localModel")
 \item{type}{the type of the LIME method implementation. Possible values are: \code{"localModel"} (default), \code{"iml"}, and \code{"lime"}}
 }
 \value{
-A raster object with the same dimensions as \code{raster_obs}. The number of layers may vary depending on the type of the LIME method implementation
+A SpatRaster object with the same dimensions as \code{raster_obs}. The number of layers it has may vary depending on the type of the LIME method implementation
 }
 \description{
 For each observation in the raster, the function returns an explanation of the model prediction using selected implementation of the LIME (Local Interpretable Model-agnostic Explanations) method.

--- a/man/map_oscillations.Rd
+++ b/man/map_oscillations.Rd
@@ -16,7 +16,7 @@ map_oscillations(
 \arguments{
 \item{explainer}{a model to be explained, preprocessed by the \code{\link[DALEX:explain]{DALEX::explain()}} function}
 
-\item{raster_obs}{a raster object with the observations to be explained (predictors used in the model)}
+\item{raster_obs}{a SpatRaster object with the observations to be explained (predictors used in the model)}
 
 \item{maxcell}{the maximum number of cells in the raster. If the number of cells in the raster is greater than \code{maxcell}, the function will sample \code{maxcell} cells from the raster. By default 1000}
 
@@ -27,7 +27,7 @@ map_oscillations(
 \item{type}{the type of variable attributions. Either \code{oscillations_uni} (default), \code{oscillations_emp}, \code{oscillations}}
 }
 \value{
-A raster object with the same dimensions as \code{raster_obs}. The number of layers equal to the number of variables in the model.
+A SpatRaster object with the same dimensions as \code{raster_obs}. The number of layers in it is equal to the number of variables in the model.
 }
 \description{
 This function calculates the attributions of the model

--- a/man/map_shap.Rd
+++ b/man/map_shap.Rd
@@ -9,7 +9,7 @@ map_shap(explainer, raster_obs, maxcell = 1000, ..., N = NULL, type = "shap")
 \arguments{
 \item{explainer}{a model to be explained, preprocessed by the \code{\link[DALEX:explain]{DALEX::explain()}} function}
 
-\item{raster_obs}{a raster object with the observations to be explained (predictors used in the model)}
+\item{raster_obs}{a SpatRaster object with the observations to be explained (predictors used in the model)}
 
 \item{maxcell}{the maximum number of cells in the raster. If the number of cells in the raster is greater than \code{maxcell}, the function will sample \code{maxcell} cells from the raster. By default 1000}
 
@@ -20,7 +20,7 @@ map_shap(explainer, raster_obs, maxcell = 1000, ..., N = NULL, type = "shap")
 \item{type}{the type of variable attributions. Only \code{"shap"} is implemented at the moment.}
 }
 \value{
-A raster object with the same dimensions as \code{raster_obs}. The number of layers equal to the number of variables in the model.
+A SpatRaster object with the same dimensions as \code{raster_obs}. The number of layers in it is equal to the number of variables in the model.
 }
 \description{
 This function calculates the attributions of the model


### PR DESCRIPTION
This PR includes very minor updates to `map_breakdown()`, `map_oscillations()` and `map_shap()` to support factor-valued raster layers passed to these functions via `raster_obs`.

Previously the `result` object that is used internally to collate the results was a simple duplicate of `x_df`, which preserved the data types of the layers in `raster_obs`, which could include factor (and presumably character, I've not tested) types, even though the output for the DALEX functions is all numeric. This led to warnings in all three functions when intermediate output was added back to `result`, and errors in `map_breakdown()` and `map_shap()` when the final `result` was inserted into the output SpatRaster.

Now the `result` object is reinitalised to contain all `NA` values, similar to the approach already used in the `map_lime()` function. This fixes the warnings and errors.

This PR also includes minor updates to the `map_*()` functions to clarify that `raster_obs` and function output are SpatRaster objects.